### PR TITLE
Dev gir

### DIFF
--- a/install-64.sh
+++ b/install-64.sh
@@ -11,9 +11,9 @@ _install() {
 	cp -v ./pixmaps/* "$1"/usr/share/caja-terminal/
 	cp -v ./code/*.glade "$1"/usr/share/caja-terminal/
 	#Caja Python
-	mkdir -pv "$1"/usr/lib64/caja/extensions-2.0/python/
-	cp -pv ./code/caja-terminal.py "$1"/usr/lib64/caja/extensions-2.0/python/
-	chmod -v 755 "$1"/usr/lib64/caja/extensions-2.0/python/caja-terminal.py
+	mkdir -pv "$1"/usr/share/caja-python/extensions/
+	cp -pv ./code/caja-terminal.py "$1"/usr/share/caja-python/extensions/
+	chmod -v 755 "$1"/usr/share/caja-python/extensions/caja-terminal.py
 	#Doc
 	mkdir -pv "$1"/usr/share/doc/caja-terminal/
 	cp -v README "$1"/usr/share/doc/caja-terminal/
@@ -37,7 +37,7 @@ _install() {
 _remove() {
 	#Remove Caja Terminal
 	rm -rv /usr/share/caja-terminal
-	rm -v /usr/lib64/caja/extensions-2.0/python/caja-terminal.py
+	rm -v /usr/share/caja-python/extensions/caja-terminal.py
 	rm -rv /usr/share/doc/caja-terminal
 	find /usr/share/locale/ -name caja-terminal.mo \
 		-exec rm -v '{}' ';'

--- a/install-64.sh
+++ b/install-64.sh
@@ -62,7 +62,7 @@ _check_dep() {
 	echo -n "   * Caja ............................ "
 	test -x /usr/bin/caja && echo "$_GREEN[OK]$_NORMAL" || { echo "$_RED[Missing]$_NORMAL" ; error=1 ; }
 	echo -n "   * Caja Python...................... "
-	test -f /usr/lib64/caja/extensions-2.0/lib64caja-python.so && echo "$_GREEN[OK]$_NORMAL" || { echo "$_RED[Missing]$_NORMAL" ; }
+	test -f /usr/lib64/caja/extensions-2.0/libcaja-python.so && echo "$_GREEN[OK]$_NORMAL" || { echo "$_RED[Missing]$_NORMAL" ; }
 	echo -n "   * Python .............................. "
 	test -x /usr/bin/python && echo "$_GREEN[OK]$_NORMAL" || { echo "$_RED[Missing]$_NORMAL" ; error=1 ; }
 	echo -n "   * Python GTK Bindings (PyGTK) ......... "

--- a/install-64.sh
+++ b/install-64.sh
@@ -62,7 +62,7 @@ _check_dep() {
 	echo -n "   * Caja ............................ "
 	test -x /usr/bin/caja && echo "$_GREEN[OK]$_NORMAL" || { echo "$_RED[Missing]$_NORMAL" ; error=1 ; }
 	echo -n "   * Caja Python...................... "
-	test -f /usr/lib64/caja/extensions-2.0/libcaja-python.so && echo "$_GREEN[OK]$_NORMAL" || { echo "$_RED[Missing]$_NORMAL" ; }
+	test -f /usr/lib64/caja/extensions-2.0/lib64caja-python.so && echo "$_GREEN[OK]$_NORMAL" || { echo "$_RED[Missing]$_NORMAL" ; }
 	echo -n "   * Python .............................. "
 	test -x /usr/bin/python && echo "$_GREEN[OK]$_NORMAL" || { echo "$_RED[Missing]$_NORMAL" ; error=1 ; }
 	echo -n "   * Python GTK Bindings (PyGTK) ......... "

--- a/install.sh
+++ b/install.sh
@@ -11,9 +11,9 @@ _install() {
 	cp -v ./pixmaps/* "$1"/usr/share/caja-terminal/
 	cp -v ./code/*.glade "$1"/usr/share/caja-terminal/
 	#Caja Python
-	mkdir -pv "$1"/usr/lib/caja/extensions-2.0/python/
-	cp -pv ./code/caja-terminal.py "$1"/usr/lib/caja/extensions-2.0/python/
-	chmod -v 755 "$1"/usr/lib/caja/extensions-2.0/python/caja-terminal.py
+	mkdir -pv "$1"/usr/share/caja-python/extensions/
+	cp -pv ./code/caja-terminal.py "$1"/usr/share/caja-python/extensions/
+	chmod -v 755 "$1"/usr/share/caja-python/extensions/caja-terminal.py
 	#Doc
 	mkdir -pv "$1"/usr/share/doc/caja-terminal/
 	cp -v README "$1"/usr/share/doc/caja-terminal/
@@ -37,7 +37,7 @@ _install() {
 _remove() {
 	#Remove Caja Terminal
 	rm -rv /usr/share/caja-terminal
-	rm -v /usr/lib/caja/extensions-2.0/python/caja-terminal.py
+	rm -v /usr/share/caja-python/extensions/caja-terminal.py
 	rm -rv /usr/share/doc/caja-terminal
 	find /usr/share/locale/ -name caja-terminal.mo \
 		-exec rm -v '{}' ';'


### PR DESCRIPTION
 My system is Rosinka 2013 → Linux Mint 15 Olivia →Ubuntu 13.04 Raring Ringtail.
Hi! I cannot  run the caja-terminal program by Linux Mint 15 Olivia Mate  Russian fork Rosinka having caja 1.6.0. 
About README file.
I cannot undastand what it means "for MATE-1.6.0, don't use python-caja-1.6.0" ?
 I do have Mate 1.6.0 and My repositories have exactly  python-caja-1.6.0. 
And what I must to do with "...don't use python-caja-1.6.0" ? 
  These addreses inside the file such as
 PyGTK 2.x <http://pygtk.org/>
 Caja Python <http://pub.mate-desktop.org/releases/1.4/python-caja>
https://dl.dropboxusercontent.com/u/49862637/Mate-desktop/patches/python-caja_removal_of_mate-python_usage.patch
doesn't work at all, "Not found".
I would be very pleased to recieve your support to install and sucsessfully  run such a beauteful applet CAJA-TERMINAL.
Thank YOU very much!